### PR TITLE
fix non-zero output unlock

### DIFF
--- a/scripts/SHUAllet_plugin.js
+++ b/scripts/SHUAllet_plugin.js
@@ -447,7 +447,7 @@ const unlockCoins = async(pkWIF, receiveAddress, txid, oIdx = 0) => {
         const lockedBlock = hex2Int(lockedBlockHex);
         bsvtx.lockUntilBlockHeight(lockedBlock);
         bsvtx.to(receiveAddress, lockedUTXO.satoshis === 1 ? 1 : lockedUTXO.satoshis - 1); // subtract 1 satoshi to pay the transaction fee
-        const solution = unlockLockScript(bsvtx.toString(), oIdx, lockedUTXO.script, lockedUTXO.satoshis, bsv.PrivateKey.fromWIF(pkWIF))
+        const solution = unlockLockScript(bsvtx.toString(), 0, lockedUTXO.script, lockedUTXO.satoshis, bsv.PrivateKey.fromWIF(pkWIF))
         bsvtx.inputs[0].setScript(solution);
         return bsvtx.toString();
     } catch(e) { console.log(e) }

--- a/scripts/bsv-lock.js
+++ b/scripts/bsv-lock.js
@@ -72,7 +72,7 @@ const unlockCoins = async(pkWIF, receiveAddress, txid, oIdx = 0) => {
         const lockedBlock = hex2Int(lockedBlockHex);
         bsvtx.lockUntilBlockHeight(lockedBlock);
         bsvtx.to(receiveAddress, lockedUTXO.satoshis === 1 ? 1 : lockedUTXO.satoshis - 1); // subtract 1 satoshi to pay the transaction fee
-        const solution = unlockLockScript(bsvtx.toString(), oIdx, lockedUTXO.script, lockedUTXO.satoshis, bsv.PrivateKey.fromWIF(pkWIF))
+        const solution = unlockLockScript(bsvtx.toString(), 0, lockedUTXO.script, lockedUTXO.satoshis, bsv.PrivateKey.fromWIF(pkWIF))
         bsvtx.inputs[0].setScript(solution);
         return bsvtx.toString();
     } catch(e) { console.log(e) }


### PR DESCRIPTION
`oIdx` was used above but is not relevant here, causing accessing out of bounds on input array which will always be length 1 / index 0.